### PR TITLE
Conversão de número inteiro para número por extenso

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+#
+# Build stage
+#
+FROM maven:3.6.0-jdk-11-slim AS build
+COPY src /home/app/src
+COPY pom.xml /home/app
+RUN mvn -f /home/app/pom.xml clean package
+
+#
+# Package stage
+#
+FROM openjdk:11-jre-slim
+COPY --from=build /home/app/target/api-0.0.1-SNAPSHOT.jar /usr/local/lib/api.jar
+EXPOSE 3000
+ENTRYPOINT ["java","-jar","/usr/local/lib/api.jar"]

--- a/src/main/java/br/com/antonio/api/controllers/NumberConversion.java
+++ b/src/main/java/br/com/antonio/api/controllers/NumberConversion.java
@@ -1,0 +1,26 @@
+package br.com.antonio.api.controllers;
+
+import br.com.antonio.api.dtos.Extenso;
+import br.com.antonio.api.services.NumberToString;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * End-Point para a conversão do número por extenso.
+ *
+ * @author Antônio Lima Jr
+ */
+@RestController
+public class NumberConversion {
+
+  @Autowired
+  private NumberToString numberToString;
+
+  @GetMapping("/{number}")
+  public ResponseEntity<Extenso> ConversionNumber(@PathVariable Integer number) {
+    return ResponseEntity.ok(numberToString.conversionNumber(number));
+  }
+}

--- a/src/main/java/br/com/antonio/api/controllers/exceptions/ControllerExceptionsHandler.java
+++ b/src/main/java/br/com/antonio/api/controllers/exceptions/ControllerExceptionsHandler.java
@@ -1,0 +1,30 @@
+package br.com.antonio.api.controllers.exceptions;
+
+import br.com.antonio.api.controllers.exceptions.responses.StandardError;
+import br.com.antonio.api.services.exceptions.NumOutOfRangeException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.Instant;
+
+/**
+ * Recebe captura os erros do sistema e retorna uma resposta personalizada.
+ *
+ * @author Antônio Lima Jr
+ */
+@ControllerAdvice
+public class ControllerExceptionsHandler {
+  @ExceptionHandler(NumOutOfRangeException.class)
+  public ResponseEntity<StandardError> entityNotFound(NumOutOfRangeException e, HttpServletRequest request) {
+    StandardError err = new StandardError();
+    err.setTimestamp(Instant.now());
+    err.setStatus(HttpStatus.NOT_FOUND.value());
+    err.setError("Número recebido fora do conjunto aceito");
+    err.setMessage(e.getMessage());
+    err.setPath(request.getRequestURI());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(err);
+  }
+}

--- a/src/main/java/br/com/antonio/api/controllers/exceptions/responses/StandardError.java
+++ b/src/main/java/br/com/antonio/api/controllers/exceptions/responses/StandardError.java
@@ -1,0 +1,26 @@
+package br.com.antonio.api.controllers.exceptions.responses;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+/**
+ * Padrão de resposta quando for capturada uma exceção.
+ *
+ * @author Antônio Lima Jr
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class StandardError implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private Instant timestamp;
+  private Integer status;
+  private String error;
+  private String message;
+  private String path;
+}

--- a/src/main/java/br/com/antonio/api/dtos/Extenso.java
+++ b/src/main/java/br/com/antonio/api/dtos/Extenso.java
@@ -1,0 +1,17 @@
+package br.com.antonio.api.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Padrão de objeto para resposta quando a conversão tiver sucesso.
+ *
+ * @author Antônio Lima Jr
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Extenso {
+  private String extenso;
+}

--- a/src/main/java/br/com/antonio/api/services/NumberToString.java
+++ b/src/main/java/br/com/antonio/api/services/NumberToString.java
@@ -2,6 +2,9 @@ package br.com.antonio.api.services;
 
 import br.com.antonio.api.dtos.Extenso;
 import br.com.antonio.api.services.exceptions.NumOutOfRangeException;
+import br.com.antonio.api.utils.ConversorExtenso;
+import br.com.antonio.api.utils.IConversorExtenso;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -11,10 +14,19 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class NumberToString {
+
+  IConversorExtenso conversor;
+
+  @Autowired
+  public NumberToString(ConversorExtenso conversor) {
+    this.conversor = conversor;
+  }
+
   public Extenso conversionNumber(Integer num) {
     if (num > 99999 || num < -99999) {
       throw new NumOutOfRangeException("O numero deve estar entre -99999 e 99999 mas recebemos o valor " + num);
     }
-    return new Extenso("numPorExtenso");
+    String numPorExtenso = conversor.convertToString(num);
+    return new Extenso(numPorExtenso);
   }
 }

--- a/src/main/java/br/com/antonio/api/services/NumberToString.java
+++ b/src/main/java/br/com/antonio/api/services/NumberToString.java
@@ -1,0 +1,20 @@
+package br.com.antonio.api.services;
+
+import br.com.antonio.api.dtos.Extenso;
+import br.com.antonio.api.services.exceptions.NumOutOfRangeException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service utilizado para verificar erros e chamar a lógica de conversão.
+ *
+ * @author Antônio Lima Jr
+ */
+@Service
+public class NumberToString {
+  public Extenso conversionNumber(Integer num) {
+    if (num > 99999 || num < -99999) {
+      throw new NumOutOfRangeException("O numero deve estar entre -99999 e 99999 mas recebemos o valor " + num);
+    }
+    return new Extenso("numPorExtenso");
+  }
+}

--- a/src/main/java/br/com/antonio/api/services/exceptions/NumOutOfRangeException.java
+++ b/src/main/java/br/com/antonio/api/services/exceptions/NumOutOfRangeException.java
@@ -1,0 +1,12 @@
+package br.com.antonio.api.services.exceptions;
+
+/**
+ * Exceção lançada caso um número esteja fora do limiar permitido.
+ *
+ * @author Antônio Lima Jr
+ */
+public class NumOutOfRangeException extends RuntimeException {
+  public NumOutOfRangeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/br/com/antonio/api/utils/ConversorExtenso.java
+++ b/src/main/java/br/com/antonio/api/utils/ConversorExtenso.java
@@ -106,7 +106,9 @@ public class ConversorExtenso implements IConversorExtenso {
    * Constrói a ‘string’ para a casa das centenas.
    */
   private void buildCentenas() {
-    if (centenas > 0) {
+    if (centenas == 1 && dezenas == 0 && unidades == 0) {
+      valueToString += "cem";
+    } else if (centenas > 0) {
       valueToString += Centenas.values()[centenas - 1].getNumToString();
       valueToString += this.conjuncao(CasasDecimais.CENTENA);
     }
@@ -116,7 +118,9 @@ public class ConversorExtenso implements IConversorExtenso {
    * Constrói a string para a casa das dezenas.
    */
   private void buildDezenas() {
-    if (dezenas > 0) {
+    if (dezenas == 1) {
+      valueToString += DezenaEspecial.values()[unidades].getNumToString();
+    } else if (dezenas > 0) {
       valueToString += Dezenas.values()[dezenas - 1].getNumToString();
       valueToString += this.conjuncao(CasasDecimais.DEZENA);
     }
@@ -126,14 +130,18 @@ public class ConversorExtenso implements IConversorExtenso {
    * Constrói a ‘string’ para a casa das unidades.
    */
   private void buildUnidades() {
-    if (unidades > 0) {
-      valueToString += Unidades.values()[unidades - 1].getNumToString();
-    } else if (unidades == 0 && dezMilhar == 0 && centenas == 0 && dezenas == 0) {
-      valueToString += "zero";
+    if (dezenas != 1) {
+      if (unidades > 0) {
+        valueToString += Unidades.values()[unidades - 1].getNumToString();
+      } else if (unidades == 0 && dezMilhar == 0 && centenas == 0 && dezenas == 0) {
+        valueToString += "zero";
+      }
     }
   }
 
   /**
+   * Verifica se existem números a ser escritos por extenso após a casa que esta sendo verificada
+   *
    * @param casaAtual é a casa atual que esta chamando a conjunção.
    * @return retorna um " e " se existir casas menores que vão ser escritas por extenso,
    * caso não exista mais casas que devem ser convertidas retorna uma ‘string’ vazia.

--- a/src/main/java/br/com/antonio/api/utils/ConversorExtenso.java
+++ b/src/main/java/br/com/antonio/api/utils/ConversorExtenso.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import org.springframework.stereotype.Component;
 
 /**
- * Receber um número inteiro no construtor e construir uma ‘string’ por extenso.
+ * Receber um número inteiro e constrói uma ‘string’ por extenso.
  *
  * @author Antônio Lima Jr
  */
@@ -23,11 +23,11 @@ public class ConversorExtenso implements IConversorExtenso {
   /**
    * Chama os métodos para converter em ‘string’ cada casa decimal.
    *
-   * @return o numero inteiro por extenso
+   * @return o número inteiro por extenso
    */
   @Override
   public String convertToString(int valorRecebido) {
-    this.qntCasasDecimais(valorRecebido);
+    this.verificaSinal(valorRecebido);
     this.buildDezMilhar();
     this.buildCentenas();
     this.buildDezenas();
@@ -42,7 +42,7 @@ public class ConversorExtenso implements IConversorExtenso {
    *
    * @param valorRecebido valor inteiro que deve ser escrito por extenso
    */
-  public void qntCasasDecimais(int valorRecebido) {
+  private void verificaSinal(int valorRecebido) {
     this.valueToString = "";
     if (valorRecebido < 0) {
       valueToString += "menos ";
@@ -94,7 +94,7 @@ public class ConversorExtenso implements IConversorExtenso {
         valueToString += Unidades.values()[(this.dezMilhar - (this.dezMilhar / 10 * 10)) - 1].getNumToString() + " mil";
         valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);
       }
-      //  Constrói a string se sua divisão por 10 for igual a 0, exemplos: 20, 30, 40, 50, 60, 70, 80, 90
+      //  Constrói a ‘string’ se a sua divisão por 10 for igual a 0, exemplos: 20, 30, 40, 50, 60, 70, 80, 90
       else {
         valueToString += Dezenas.values()[(this.dezMilhar / 10) - 1].getNumToString() + " mil";
         valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);

--- a/src/main/java/br/com/antonio/api/utils/ConversorExtenso.java
+++ b/src/main/java/br/com/antonio/api/utils/ConversorExtenso.java
@@ -1,0 +1,164 @@
+package br.com.antonio.api.utils;
+
+
+import br.com.antonio.api.utils.enums.*;
+import lombok.Data;
+import org.springframework.stereotype.Component;
+
+/**
+ * Receber um número inteiro no construtor e construir uma ‘string’ por extenso.
+ *
+ * @author Antônio Lima Jr
+ */
+@Data
+@Component
+public class ConversorExtenso implements IConversorExtenso {
+  private String valueToString;
+
+  private int dezMilhar;
+  private int centenas;
+  private int dezenas;
+  private int unidades;
+
+  /**
+   * Chama os métodos para converter em ‘string’ cada casa decimal.
+   *
+   * @return o numero inteiro por extenso
+   */
+  @Override
+  public String convertToString(int valorRecebido) {
+    this.qntCasasDecimais(valorRecebido);
+    this.buildDezMilhar();
+    this.buildCentenas();
+    this.buildDezenas();
+    this.buildUnidades();
+    return valueToString;
+  }
+
+  /**
+   * Inicializa ‘string’ com "menos" se for menor que zero
+   * e chama o método qntCasas para contabilizar a quantidade
+   * de dezenas de milhares, centenas, dezenas, unidades.
+   *
+   * @param valorRecebido valor inteiro que deve ser escrito por extenso
+   */
+  public void qntCasasDecimais(int valorRecebido) {
+    this.valueToString = "";
+    if (valorRecebido < 0) {
+      valueToString += "menos ";
+      valorRecebido = valorRecebido * -1;
+    }
+    this.qntCasas(valorRecebido);
+  }
+
+  /**
+   * Faz a divisão e recupera a quantidade das dezenas de milhares, centenas, dezenas e unidades.
+   *
+   * @param valorRecebido número que deve ser escrito por extenso.
+   */
+  private void qntCasas(int valorRecebido) {
+    this.dezMilhar = valorRecebido / 1000;
+    valorRecebido -= this.dezMilhar * 1000;
+    this.centenas = valorRecebido / 100;
+    valorRecebido -= this.centenas * 100;
+    this.dezenas = valorRecebido / 10;
+    valorRecebido -= this.dezenas * 10;
+    this.unidades = valorRecebido;
+  }
+
+  /**
+   * Verifica quantas dezenas ou unidades de milhar existe no inteiro em questão
+   * e recupera do enum a ‘string’ correspondente.
+   */
+  private void buildDezMilhar() {
+    if (this.dezMilhar > 0) {
+      //  Constrói a string entre mil e 9 mil
+      if ((this.dezMilhar / 10) < 1) {
+        if (this.dezMilhar == 1) {
+          valueToString += "mil";
+          valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);
+        } else {
+          valueToString += Unidades.values()[this.dezMilhar - 1].getNumToString() + " mil";
+          valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);
+        }
+      }
+      //  Constrói a string entre 10 mil e 19 mil
+      else if ((this.dezMilhar / 10) < 2) {
+        valueToString += DezenaEspecial.values()[(this.dezMilhar - 10)].getNumToString() + " mil";
+        valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);
+      }
+      //  Constrói a ‘string’ se a sua divisão por 10 diferir de 0, exemplos: 23, 35, 47, 59, 77, 82, 94
+      else if ((this.dezMilhar % 10) != 0) {
+        valueToString += Dezenas.values()[(this.dezMilhar / 10) - 1].getNumToString();
+        valueToString += this.conjuncao();
+        valueToString += Unidades.values()[(this.dezMilhar - (this.dezMilhar / 10 * 10)) - 1].getNumToString() + " mil";
+        valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);
+      }
+      //  Constrói a string se sua divisão por 10 for igual a 0, exemplos: 20, 30, 40, 50, 60, 70, 80, 90
+      else {
+        valueToString += Dezenas.values()[(this.dezMilhar / 10) - 1].getNumToString() + " mil";
+        valueToString += this.conjuncao(CasasDecimais.DEZMILHAR);
+      }
+    }
+  }
+
+  /**
+   * Constrói a ‘string’ para a casa das centenas.
+   */
+  private void buildCentenas() {
+    if (centenas > 0) {
+      valueToString += Centenas.values()[centenas - 1].getNumToString();
+      valueToString += this.conjuncao(CasasDecimais.CENTENA);
+    }
+  }
+
+  /**
+   * Constrói a string para a casa das dezenas.
+   */
+  private void buildDezenas() {
+    if (dezenas > 0) {
+      valueToString += Dezenas.values()[dezenas - 1].getNumToString();
+      valueToString += this.conjuncao(CasasDecimais.DEZENA);
+    }
+  }
+
+  /**
+   * Constrói a ‘string’ para a casa das unidades.
+   */
+  private void buildUnidades() {
+    if (unidades > 0) {
+      valueToString += Unidades.values()[unidades - 1].getNumToString();
+    } else if (unidades == 0 && dezMilhar == 0 && centenas == 0 && dezenas == 0) {
+      valueToString += "zero";
+    }
+  }
+
+  /**
+   * @param casaAtual é a casa atual que esta chamando a conjunção.
+   * @return retorna um " e " se existir casas menores que vão ser escritas por extenso,
+   * caso não exista mais casas que devem ser convertidas retorna uma ‘string’ vazia.
+   */
+  private String conjuncao(CasasDecimais casaAtual) {
+    if (casaAtual == CasasDecimais.DEZMILHAR) {
+      if (this.centenas > 0 || this.dezenas > 0 || this.unidades > 0) {
+        return " e ";
+      }
+    } else if (casaAtual == CasasDecimais.CENTENA) {
+      if (this.dezenas > 0 || this.unidades > 0) {
+        return " e ";
+      }
+    } else if (casaAtual == CasasDecimais.DEZENA) {
+      if (this.unidades > 0) {
+        return " e ";
+      }
+    }
+    return "";
+  }
+
+  /**
+   * @return retorna sempre a conjunção" e ".
+   */
+  private String conjuncao() {
+    return " e ";
+  }
+}

--- a/src/main/java/br/com/antonio/api/utils/IConversorExtenso.java
+++ b/src/main/java/br/com/antonio/api/utils/IConversorExtenso.java
@@ -1,0 +1,10 @@
+package br.com.antonio.api.utils;
+
+/**
+ * Interface para desacoplar as suas implementações.
+ *
+ * @author Antônio Lima Jr
+ */
+public interface IConversorExtenso {
+  String convertToString(int valorParaConverter);
+}

--- a/src/main/java/br/com/antonio/api/utils/enums/CasasDecimais.java
+++ b/src/main/java/br/com/antonio/api/utils/enums/CasasDecimais.java
@@ -1,0 +1,21 @@
+package br.com.antonio.api.utils.enums;
+
+/**
+ * Padroniza as casas decimais.
+ *
+ * @author Antônio Lima Jr
+ */
+public enum CasasDecimais {
+  DEZMILHAR(0), CENTENA(1), DEZENA(2), UNIDADE(3);
+
+
+  private final int numToString;
+
+  CasasDecimais(int valor) {
+    this.numToString = valor;
+  }
+
+  public int getNumToString() {
+    return numToString;
+  }
+}

--- a/src/main/java/br/com/antonio/api/utils/enums/Centenas.java
+++ b/src/main/java/br/com/antonio/api/utils/enums/Centenas.java
@@ -1,0 +1,23 @@
+package br.com.antonio.api.utils.enums;
+
+/**
+ * Enum das centenas.
+ *
+ * @author Antônio Lima Jr
+ */
+public enum Centenas {
+  CENTO("cento"), DUZENTOS("duzentos"), TREZENTOS("trezentos"),
+  QUATROCENTOS("quatrocentos"), QUINHENTOS("quinhentos"),
+  SEISCENTOS("seiscentos"), SETECENTOS("setecentos"),
+  OITOCENTOS("oitocentos"), NOVECENTOS("novecentos");
+
+  private final String numToString;
+
+  Centenas(String valor) {
+    this.numToString = valor;
+  }
+
+  public String getNumToString() {
+    return numToString;
+  }
+}

--- a/src/main/java/br/com/antonio/api/utils/enums/DezenaEspecial.java
+++ b/src/main/java/br/com/antonio/api/utils/enums/DezenaEspecial.java
@@ -1,0 +1,22 @@
+package br.com.antonio.api.utils.enums;
+
+/**
+ * Enum da DezenaEspecial.
+ *
+ * @author Antônio Lima Jr
+ */
+public enum DezenaEspecial {
+  DEZ("dez"), ONZE("onze"), DOZE("doze"), TREZE("treze"),
+  QUATORZE("quatorze"), QUINZE("quinze"), DEZESSEIS("dezesseis"),
+  DEZESSETE("dezessete"), DEZOITO("dezoito"), DEZENOVE("dezenove");
+
+  private final String numToString;
+
+  DezenaEspecial(String valor) {
+    this.numToString = valor;
+  }
+
+  public String getNumToString() {
+    return numToString;
+  }
+}

--- a/src/main/java/br/com/antonio/api/utils/enums/Dezenas.java
+++ b/src/main/java/br/com/antonio/api/utils/enums/Dezenas.java
@@ -1,0 +1,23 @@
+package br.com.antonio.api.utils.enums;
+
+/**
+ * Enum das dezenas.
+ *
+ * @author Antônio Lima Jr
+ */
+public enum Dezenas {
+  DEZ("dez"), VINTE("vinte"), TRINTA("trinta"),
+  QUARENTA("quarenta"), CINQUENTA("cinquenta"),
+  SESSENTA("sessenta"), SETENTA("setenta"),
+  OITENTA("oitenta"), NOVENTA("noventa");
+
+  private final String numToString;
+
+  Dezenas(String valor) {
+    this.numToString = valor;
+  }
+
+  public String getNumToString() {
+    return numToString;
+  }
+}

--- a/src/main/java/br/com/antonio/api/utils/enums/Unidades.java
+++ b/src/main/java/br/com/antonio/api/utils/enums/Unidades.java
@@ -1,0 +1,22 @@
+package br.com.antonio.api.utils.enums;
+
+/**
+ * Enum das unidades.
+ *
+ * @author Antônio Lima Jr
+ */
+public enum Unidades {
+  UM("um"), DOIS("dois"), TRES("três"), QUATRO("quatro"),
+  CINCO("cinco"), SEIS("seis"), SETE("sete"), OITO("oito"),
+  NOVE("nove");
+
+  private final String numToString;
+
+  Unidades(String valor) {
+    this.numToString = valor;
+  }
+
+  public String getNumToString() {
+    return numToString;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.port=3000

--- a/src/test/java/br/com/antonio/api/services/NumberToStringTest.java
+++ b/src/test/java/br/com/antonio/api/services/NumberToStringTest.java
@@ -1,0 +1,60 @@
+package br.com.antonio.api.services;
+
+import br.com.antonio.api.services.exceptions.NumOutOfRangeException;
+import br.com.antonio.api.utils.ConversorExtenso;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Teste do Serviço number to string.
+ *
+ * @author Antônio Lima Jr
+ */
+@ExtendWith(MockitoExtension.class)
+class NumberToStringTest {
+
+  @InjectMocks
+  private NumberToString numberToString;
+
+  @Mock
+  private ConversorExtenso conversor;
+
+  @Test
+  void conversaoNumeroForaDaEspecificacao_TestarExcecao() {
+    int num1 = 100000;
+    int num2 = -100000;
+
+    try {
+      numberToString.conversionNumber(num1);
+    } catch (NumOutOfRangeException ex) {
+      assertEquals("O numero deve estar entre -99999 e 99999 mas recebemos o valor " + num1, ex.getMessage());
+    }
+    try {
+      numberToString.conversionNumber(num2);
+    } catch (NumOutOfRangeException ex) {
+      assertEquals("O numero deve estar entre -99999 e 99999 mas recebemos o valor " + num2, ex.getMessage());
+    }
+  }
+
+  @Test
+  void testConversao_TestarNumeroPorExtenso() {
+    int valor1 = 1954;
+    String valorEsperado1 = "mil e novecentos e cinquenta e quatro";
+    int valor2 = -1543;
+    String valorEsperado2 = "menos mil e quinhentos e quarenta e três";
+
+    Mockito.when(this.conversor.convertToString(valor1))
+        .thenReturn(valorEsperado1);
+    Mockito.when(this.conversor.convertToString(valor2))
+        .thenReturn(valorEsperado2);
+
+    assertEquals(numberToString.conversionNumber(valor1).getExtenso(), valorEsperado1);
+    assertEquals(numberToString.conversionNumber(valor2).getExtenso(), valorEsperado2);
+  }
+}

--- a/src/test/java/br/com/antonio/api/utils/ConversorExtensoTest.java
+++ b/src/test/java/br/com/antonio/api/utils/ConversorExtensoTest.java
@@ -1,0 +1,40 @@
+package br.com.antonio.api.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Teste Conversor de números por extenso.
+ *
+ * @author Antônio Lima Jr
+ */
+class ConversorExtensoTest {
+
+  @Test
+  void qntCasasDecimais_TestaUnidadesDeCadaCasaDecimal() {
+    int valor = 9999;
+    ConversorExtenso conversorWithEnum = new ConversorExtenso();
+    conversorWithEnum.convertToString(valor);
+    int valorEsperado = 9;
+
+    assertEquals(conversorWithEnum.getDezMilhar(), valorEsperado);
+    assertEquals(conversorWithEnum.getCentenas(), valorEsperado);
+    assertEquals(conversorWithEnum.getDezenas(), valorEsperado);
+    assertEquals(conversorWithEnum.getUnidades(), valorEsperado);
+  }
+
+  @Test
+  void getValueToString_TestarNumeroPorExtenso() {
+    int valor1 = 99999;
+    int valor2 = -8855;
+    int valor3 = -15;
+    String valorEsperado1 = "noventa e nove mil e novecentos e noventa e nove";
+    String valorEsperado2 = "menos oito mil e oitocentos e cinquenta e cinco";
+    String valorEsperado3 = "menos quinze";
+
+    assertEquals(new ConversorExtenso().convertToString(valor1), valorEsperado1);
+    assertEquals(new ConversorExtenso().convertToString(valor2), valorEsperado2);
+    assertEquals(new ConversorExtenso().convertToString(valor3), valorEsperado3);
+  }
+}


### PR DESCRIPTION
End-point para conversão de inteiro para um número por extenso.

* Adiciona a camada de controllers é responsável apenas pela configuração das requisições.
* Adiciona a camada de serviços é responsável por capturar erros e utilizar a classe de conversão do número.
* Adiciona a classe responsável por fazer a conversão de inteiro para o número por extenso.
* Adiciona os testes nas classes críticas do sistema.
* Adiciona um handler de exceções para devolver uma resposta de erro personalizada.

Desenvolvimento

Primeiramente utilizei a interface map do java para transformar os números por extenso de acordo com Inteiro requisitado, porém, optei mais tarde por utilizar enum por achar mais organizado separar as strings de cada casa decimal em um arquivo.

A classe de conversão funciona da seguinte maneira:
É passado um valor como parâmetro para o método convertToString que chama uma rotina de construção da string.
- O primeiro método verifica o sinal e caso seja menor que 0 adiciona um 'menos' na string, após isso chama qntCasasDecimais que faz a separação das casas decimais, neste processo distribui em 4 variáveis que correspondem as dezenas de milhares, centenas, dezenas e unidades.
- Os métodos subjacentes da rotina tem o objetivo de consultar as suas respectivas variáveis e construir a string de acordo com o valor contido nas mesmas.
- Ao concluir a rotina temos o retorno do número por extenso.
